### PR TITLE
Update ESLint configuration export and version bump to 1.0.2

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-export default [
+module.exports = [
   {
     ignores: ['node_modules/**', 'coverage/**'],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@OtavioSerafim/pacote-notificacoes",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@OtavioSerafim/pacote-notificacoes",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^9.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@OtavioSerafim/pacote-notificacoes",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Sistema de notificações configurável e reutilizável",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Change the export format of the ESLint configuration file to use `module.exports` and update the package version to 1.0.2 in both `package.json` and `package-lock.json`.